### PR TITLE
fix(stale): add missing caller permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,14 @@ jobs:
     pr-validation:
         if: github.event_name == 'pull_request'
         uses: apermo/reusable-workflows/.github/workflows/reusable-pr-validation.yml@main
+        permissions:
+            contents: read
+            pull-requests: write
     conventional-commits:
         uses: apermo/reusable-workflows/.github/workflows/reusable-conventional-commits.yml@main
     release:
         if: github.event_name == 'push'
         uses: apermo/reusable-workflows/.github/workflows/reusable-release.yml@main
+        permissions:
+            contents: write
+            pull-requests: write

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -10,3 +10,6 @@ on:
 jobs:
     prerelease:
         uses: apermo/reusable-workflows/.github/workflows/reusable-prerelease.yml@main
+        permissions:
+            contents: write
+            pull-requests: write

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,3 +7,6 @@ on:
 jobs:
     stale:
         uses: apermo/reusable-workflows/.github/workflows/reusable-stale.yml@main
+        permissions:
+            issues: write
+            pull-requests: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Initial project setup
+
+### Fixed
+
+- Workflow callers missing permissions (caused startup_failure)


### PR DESCRIPTION
Add issues:write and pull-requests:write to stale caller. Without explicit permissions, the reusable workflow fails with startup_failure on repos with restricted default token permissions.