### PR TITLE
feat: add Gemini code review config

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,19 @@
+have_fun: true
+
+ignore_patterns:
+  - "vendor/**"
+  - "node_modules/**"
+  - "*.min.js"
+  - "*.min.css"
+  - "package-lock.json"
+  - "composer.lock"
+
+code_review:
+  disable: false
+  comment_severity_threshold: MEDIUM
+  max_review_comments: -1
+  pull_request_opened:
+    help: false
+    summary: true
+    code_review: true
+    include_drafts: true

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -4,6 +4,21 @@
 
 This is a GitHub template repository for bootstrapping new projects. A `setup.sh` script lets developers configure the project name, namespace, and description.
 
+## Code Style
+
+- Flag inline comments that merely restate what the code does instead of explaining intent or reasoning.
+- Flag commented-out code.
+- Do not flag docblocks — these may be required by coding standards even when the function is self-explanatory.
+- Flag new code that duplicates existing functionality in the repository.
+
+## File Operations
+
+- Flag files that appear to be deleted and re-added as new files instead of being moved/renamed (losing git history).
+
+## Build & Packaging
+
+- Flag newly added files or directories that are missing from build/packaging configs (`.gitattributes`, `Makefile`, CI workflows, etc.).
+
 ## Testing
 
 - If tests exist for a changed area, flag missing or insufficient test coverage for new/modified code.

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -16,7 +16,11 @@ This is a generic GitHub template repository for bootstrapping PHP projects (plu
 ## Testing
 
 - Unit tests use PHPUnit.
-- Follow TDD: write tests first, verify they fail, then implement.
+- If tests exist for a changed area, flag missing or insufficient test coverage for new/modified code.
+
+## Documentation
+
+- If a change affects user-facing behavior, flag missing updates to README, CHANGELOG, or inline docblocks.
 
 ## Commits
 

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -1,21 +1,11 @@
-# Template Repository - Code Review Style Guide
+# Code Review Style Guide
 
 ## Project Context
 
-This is a generic GitHub template repository for bootstrapping PHP projects (plugins, themes, libraries). A `setup.sh` script lets developers configure the project name, namespace, and description. PHP 8.1+ minimum, strict types everywhere.
-
-## PHP
-
-- Use tabs for indentation (not spaces).
-- All files must declare `declare(strict_types=1)`.
-- PSR-4 autoloading under `src/`.
-- Use post-increment (`$i++`) over pre-increment (`++$i`).
-- Coding standards are enforced via PHPCS.
-- Static analysis via PHPStan.
+This is a GitHub template repository for bootstrapping new projects. A `setup.sh` script lets developers configure the project name, namespace, and description.
 
 ## Testing
 
-- Unit tests use PHPUnit.
 - If tests exist for a changed area, flag missing or insufficient test coverage for new/modified code.
 
 ## Documentation
@@ -26,3 +16,8 @@ This is a generic GitHub template repository for bootstrapping PHP projects (plu
 
 - This project uses Conventional Commits with a 50-char subject / 72-char body limit.
 - Each commit should address a single concern.
+
+<!-- Add language-specific rules below as needed, e.g. coding style,
+     indentation, naming conventions, or framework-specific guidelines.
+     This keeps the base template generic while allowing derived
+     projects to tailor reviews to their stack. -->

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -1,0 +1,24 @@
+# Template Repository - Code Review Style Guide
+
+## Project Context
+
+This is a generic GitHub template repository for bootstrapping PHP projects (plugins, themes, libraries). A `setup.sh` script lets developers configure the project name, namespace, and description. PHP 8.1+ minimum, strict types everywhere.
+
+## PHP
+
+- Use tabs for indentation (not spaces).
+- All files must declare `declare(strict_types=1)`.
+- PSR-4 autoloading under `src/`.
+- Use post-increment (`$i++`) over pre-increment (`++$i`).
+- Coding standards are enforced via PHPCS.
+- Static analysis via PHPStan.
+
+## Testing
+
+- Unit tests use PHPUnit.
+- Follow TDD: write tests first, verify they fail, then implement.
+
+## Commits
+
+- This project uses Conventional Commits with a 50-char subject / 72-char body limit.
+- Each commit should address a single concern.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.0] - Unreleased
+## [0.2.0] - 2026-03-15
+
+### Added
+
+- Gemini Code Assist configuration (`.gemini/config.yaml`)
+- Code review styleguide with rules for comment quality, code reuse, file operations, build/packaging, testing, documentation, and commits
+
+## [0.1.0] - 2026-03-15
 
 ### Added
 


### PR DESCRIPTION
## Summary

- Add `.gemini/config.yaml` with review settings (severity threshold, ignore patterns, draft inclusion)
- Add `.gemini/styleguide.md` with project-specific coding conventions for Gemini Code Assist reviews

Ported from apermo/template-wordpress#14.